### PR TITLE
Privacy and orientation

### DIFF
--- a/Piano/Piano.apparmor
+++ b/Piano/Piano.apparmor
@@ -1,7 +1,6 @@
 {
     "policy_groups": [
         "audio",
-        "networking"
     ],
     "policy_version": 1.2
 }

--- a/Piano/main.qml
+++ b/Piano/main.qml
@@ -17,7 +17,7 @@ MainView {
      This property enables the application to change orientation
      when the device is rotated. The default is false.
     */
-    //automaticOrientation: true
+    automaticOrientation: false
 
     // Removes the old toolbar and enables new features of the new header.
     useDeprecatedToolbar: false


### PR DESCRIPTION
Hi Zachary,
Thanks for your awesome app! It would be great if you could change two little things:

First: Orientation should always be portrait orientation.

Second: Please disable access to the network. Regarding privacy this is for many people important and I think for using the Piano network access is not necessary, isn't it?

I have no experience in QT and qml but nevertheless I tried a solution,
Perhaps this is helpful?
Thanks in Advance,
Max